### PR TITLE
Implement `tearDown()`

### DIFF
--- a/src/test_case.py
+++ b/src/test_case.py
@@ -10,3 +10,4 @@ class TestCase:
         self.setUp()
         method = getattr(self, self.name)
         method()
+        self.tearDown()

--- a/src/test_case.py
+++ b/src/test_case.py
@@ -11,3 +11,6 @@ class TestCase:
         method = getattr(self, self.name)
         method()
         self.tearDown()
+
+    def tearDown(self) -> None:
+        pass

--- a/src/test_case_test.py
+++ b/src/test_case_test.py
@@ -12,7 +12,7 @@ class TestCaseTest(TestCase):
 
     def testSetup(self) -> None:
         self.test.run()
-        assert (self.test.wasSetUp)
+        assert ("setUp " == self.test.log)
 
 
 TestCaseTest("testRunning").run()

--- a/src/test_case_test.py
+++ b/src/test_case_test.py
@@ -12,7 +12,7 @@ class TestCaseTest(TestCase):
 
     def testSetup(self) -> None:
         self.test.run()
-        assert ("setUp " == self.test.log)
+        assert ("setUp testMethod " == self.test.log)
 
 
 TestCaseTest("testRunning").run()

--- a/src/test_case_test.py
+++ b/src/test_case_test.py
@@ -6,7 +6,7 @@ class TestCaseTest(TestCase):
     def testTemplateMethod(self) -> None:
         test = WasRun("testMethod")
         test.run()
-        assert ("setUp testMethod " == test.log)
+        assert ("setUp testMethod tearDown " == test.log)
 
 
 TestCaseTest("testTemplateMethod").run()

--- a/src/test_case_test.py
+++ b/src/test_case_test.py
@@ -6,14 +6,9 @@ class TestCaseTest(TestCase):
     def setUp(self) -> None:
         self.test = WasRun("testMethod")
 
-    def testRunning(self) -> None:
-        self.test.run()
-        assert (self.test.wasRun)
-
     def testSetup(self) -> None:
         self.test.run()
         assert ("setUp testMethod " == self.test.log)
 
 
-TestCaseTest("testRunning").run()
 TestCaseTest("testSetup").run()

--- a/src/test_case_test.py
+++ b/src/test_case_test.py
@@ -6,9 +6,9 @@ class TestCaseTest(TestCase):
     def setUp(self) -> None:
         self.test = WasRun("testMethod")
 
-    def testSetup(self) -> None:
+    def testTemplateMethod(self) -> None:
         self.test.run()
         assert ("setUp testMethod " == self.test.log)
 
 
-TestCaseTest("testSetup").run()
+TestCaseTest("testTemplateMethod").run()

--- a/src/test_case_test.py
+++ b/src/test_case_test.py
@@ -3,12 +3,10 @@ from was_run import WasRun
 
 
 class TestCaseTest(TestCase):
-    def setUp(self) -> None:
-        self.test = WasRun("testMethod")
-
     def testTemplateMethod(self) -> None:
-        self.test.run()
-        assert ("setUp testMethod " == self.test.log)
+        test = WasRun("testMethod")
+        test.run()
+        assert ("setUp testMethod " == test.log)
 
 
 TestCaseTest("testTemplateMethod").run()

--- a/src/was_run.py
+++ b/src/was_run.py
@@ -11,3 +11,4 @@ class WasRun(TestCase):
 
     def testMethod(self) -> None:
         self.wasRun = 1
+        self.log = self.log + "testMethod "

--- a/src/was_run.py
+++ b/src/was_run.py
@@ -7,7 +7,6 @@ class WasRun(TestCase):
 
     def setUp(self) -> None:
         self.wasRun = None
-        self.wasSetUp = 1
         self.log = "setUp "
 
     def testMethod(self) -> None:

--- a/src/was_run.py
+++ b/src/was_run.py
@@ -8,6 +8,7 @@ class WasRun(TestCase):
     def setUp(self) -> None:
         self.wasRun = None
         self.wasSetUp = 1
+        self.log = "setUp "
 
     def testMethod(self) -> None:
         self.wasRun = 1

--- a/src/was_run.py
+++ b/src/was_run.py
@@ -12,3 +12,6 @@ class WasRun(TestCase):
     def testMethod(self) -> None:
         self.wasRun = 1
         self.log = self.log + "testMethod "
+
+    def tearDown(self) -> None:
+        self.log = self.log + "tearDown "


### PR DESCRIPTION
## Chapter 20: Cleaning up after

Our goal in this chapter was to implement some form of clean-up mechanism so our tests always start from a clean slate. Our approach here was to introduce a `tearDown()` method to be called after the test method was run.

### Implementation checklist:
✅ ~Invoke tearDown afterward~
☑️ Invoke tearDown even if the test method fails
☑️ Run multiple tests
☑️ Report collected results
✅ ~Log string in WasRun~

Closes #6 