### PR TITLE
Report failed tests

### DIFF
--- a/src/test_case.py
+++ b/src/test_case.py
@@ -13,8 +13,13 @@ class TestCase:
         result = TestResult()
         result.testStarted()
         self.setUp()
-        method = getattr(self, self.name)
-        method()
+
+        try:
+            method = getattr(self, self.name)
+            method()
+        except:
+            result.testFailed()
+
         self.tearDown()
         return result
 

--- a/src/test_case.py
+++ b/src/test_case.py
@@ -12,7 +12,12 @@ class TestCase:
     def run(self) -> None:
         result = TestResult()
         result.testStarted()
-        self.setUp()
+
+        try:
+            self.setUp()
+        except:
+            result.testFailed()
+            return result
 
         try:
             method = getattr(self, self.name)

--- a/src/test_case_test.py
+++ b/src/test_case_test.py
@@ -22,3 +22,4 @@ class TestCaseTest(TestCase):
 
 TestCaseTest("testTemplateMethod").run()
 TestCaseTest("testFailedResultFormatting").run()
+TestCaseTest("testFailedResult").run()

--- a/src/test_case_test.py
+++ b/src/test_case_test.py
@@ -1,6 +1,6 @@
 from test_case import TestCase
 from was_run import WasRun
-
+from test_result import TestResult
 
 class TestCaseTest(TestCase):
     def testTemplateMethod(self) -> None:
@@ -13,6 +13,12 @@ class TestCaseTest(TestCase):
         result = test.run()
         assert ("1 run, 1 failed" == result.summary())
 
+    def testFailedResultFormatting(self) -> None:
+        result = TestResult()
+        result.testStarted()
+        result.testFailed()
+        assert ("1 run, 1 failed" == result.summary())
+
 
 TestCaseTest("testTemplateMethod").run()
-TestCaseTest("testFailedResult").run()
+TestCaseTest("testFailedResultFormatting").run()

--- a/src/test_case_test.py
+++ b/src/test_case_test.py
@@ -2,6 +2,19 @@ from test_case import TestCase
 from was_run import WasRun
 from test_result import TestResult
 
+
+class TestCaseTestWithBrokenSetup(TestCase):
+    def __init__(self, name) -> None:
+        TestCase.__init__(self, name)
+
+    def setUp(self) -> None:
+        raise Exception
+
+    def testFailedSetUp(self) -> None:
+        result = self.run()
+        assert ("1 run, 1 failed" == result.summary())
+
+
 class TestCaseTest(TestCase):
     def testTemplateMethod(self) -> None:
         test = WasRun("testMethod")
@@ -23,3 +36,4 @@ class TestCaseTest(TestCase):
 TestCaseTest("testTemplateMethod").run()
 TestCaseTest("testFailedResultFormatting").run()
 TestCaseTest("testFailedResult").run()
+TestCaseTestWithBrokenSetup("testFailedSetUp").run()

--- a/src/test_result.py
+++ b/src/test_result.py
@@ -1,9 +1,13 @@
 class TestResult:
     def __init__(self) -> None:
         self.runCount = 0
+        self.errorCount = 0
 
     def testStarted(self) -> None:
         self.runCount = self.runCount + 1
+
+    def testFailed(self) -> None:
+        self.errorCount = self.errorCount + 1
 
     def summary(self):
         return "%d run, 0 failed" % self.runCount

--- a/src/test_result.py
+++ b/src/test_result.py
@@ -10,4 +10,4 @@ class TestResult:
         self.errorCount = self.errorCount + 1
 
     def summary(self):
-        return "%d run, 0 failed" % self.runCount
+        return "%d run, %d failed" % (self.runCount, self.errorCount)


### PR DESCRIPTION
## Chapter 22: Dealing with failure

Our goal in this chapter was to implement a way to capture failed tests and report them, which we managed to accomplish by implementing a new counter for errors in `TestResult` and using it at `TestCase`.

### Implementation checklist:

✅ ~Invoke `tearDown` afterward~
☑️ Invoke `tearDown` even if the test method fails
☑️ Run multiple tests
✅ ~Report collected results~
✅ ~Report failed tests~
✅ ~Catch and report `setUp` errors~

Closes #11 