### PR TITLE
Handle failures at `tearDown()`

### DIFF
--- a/src/broken_teardown.py
+++ b/src/broken_teardown.py
@@ -1,0 +1,11 @@
+from test_case import TestCase
+
+class TestCaseWithBrokenTearDown(TestCase):
+    def __init__(self, name: str) -> None:
+        TestCase.__init__(self, name)
+
+    def testMethod(self) -> None:
+        pass
+
+    def tearDown(self) -> None:
+        raise Exception

--- a/src/test_case.py
+++ b/src/test_case.py
@@ -24,7 +24,10 @@ class TestCase:
         except:
             result.testFailed()
 
-        self.tearDown()
+        try:
+            self.tearDown()
+        except:
+            result.testFailed()
 
     def tearDown(self) -> None:
         pass

--- a/src/test_case_test.py
+++ b/src/test_case_test.py
@@ -4,7 +4,6 @@ from test_result import TestResult
 from broken_setup import TestCaseWithBrokenSetup
 from test_suite import TestSuite
 
-
 class TestCaseTest(TestCase):
     def setUp(self) -> None:
         self.result = TestResult()
@@ -37,6 +36,11 @@ class TestCaseTest(TestCase):
         suite.run(self.result)
         assert ("2 run, 1 failed" == self.result.summary())
 
+    def testFailedTearDown(self) -> None:
+        test = TestCaseWithBrokenTearDown("testMethod")
+        test.run(self.result)
+        assert ("1 run, 1 failed" == self.result.summary())
+
 
 suite = TestSuite()
 suite.add(TestCaseTest("testTemplateMethod"))
@@ -44,6 +48,7 @@ suite.add(TestCaseTest("testFailedResultFormatting"))
 suite.add(TestCaseTest("testFailedResult"))
 suite.add(TestCaseTest("testFailedSetUp"))
 suite.add(TestCaseTest("testSuite"))
+suite.add(TestCaseTest("testFailedTearDown"))
 
 result = TestResult()
 suite.run(result)

--- a/src/test_case_test.py
+++ b/src/test_case_test.py
@@ -3,6 +3,7 @@ from was_run import WasRun
 from test_result import TestResult
 from broken_setup import TestCaseWithBrokenSetup
 from test_suite import TestSuite
+from broken_teardown import TestCaseWithBrokenTearDown
 
 class TestCaseTest(TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
## Bonus: handle failures at `tearDown()`

Our goal in this PR was to make sure that exceptions in the `tearDown()` step were caught and reported back to the test client. We accomplish that by wrapping the call to this method with a `try/except` block. 

Closes #19 