### PR TITLE
Invoke `tearDown()` even if test fails

### DIFF
--- a/src/test_case_test.py
+++ b/src/test_case_test.py
@@ -42,6 +42,11 @@ class TestCaseTest(TestCase):
         test.run(self.result)
         assert ("1 run, 1 failed" == self.result.summary())
 
+    def testTearDownCalledEvenIfTestFails(self) -> None:
+        test = WasRun("testBrokenMethod")
+        test.run(self.result)
+        assert ("setUp testBrokenMethod tearDown " == test.log)
+
 
 suite = TestSuite()
 suite.add(TestCaseTest("testTemplateMethod"))
@@ -50,6 +55,7 @@ suite.add(TestCaseTest("testFailedResult"))
 suite.add(TestCaseTest("testFailedSetUp"))
 suite.add(TestCaseTest("testSuite"))
 suite.add(TestCaseTest("testFailedTearDown"))
+suite.add(TestCaseTest("testTearDownCalledEvenIfTestFails"))
 
 result = TestResult()
 suite.run(result)

--- a/src/was_run.py
+++ b/src/was_run.py
@@ -17,4 +17,5 @@ class WasRun(TestCase):
         self.log = self.log + "tearDown "
 
     def testBrokenMethod(self) -> None:
+        self.log = self.log + "testBrokenMethod "
         raise Exception


### PR DESCRIPTION
## Bonus: make sure `tearDown()` is called even if the test fails

Our goal in this PR was to make sure `tearDown()` is being called even if the test executed has failed. This behavior was actually already in place, so a test was added to make sure it remains working and a log entry was added to the call log so we can inspect the data in the correct order.

Closes #18 