### PR TITLE
Create `TestSuite` from `TestCase`

### DIFF
--- a/src/no_op_test_case.py
+++ b/src/no_op_test_case.py
@@ -1,0 +1,9 @@
+from test_case import TestCase
+
+
+class NoOpTestCase(TestCase):
+    def testMethod(self) -> None:
+        pass
+    
+    def testMethod2(self) -> None:
+        pass

--- a/src/test_case.py
+++ b/src/test_case.py
@@ -1,3 +1,6 @@
+from test_suite import TestSuite
+
+
 class TestCase:
 
     def __init__(self, name) -> None:
@@ -33,3 +36,10 @@ class TestCase:
         testNames = [testName for testName in dir(
             self) if testName.startswith("test")]
         return testNames
+
+    def asSuite(self):
+        suite = TestSuite()
+        testNames = self.getTestNames()
+        for testName in testNames:
+            suite.add(self.__class__(testName))
+        return suite

--- a/src/test_case.py
+++ b/src/test_case.py
@@ -28,3 +28,8 @@ class TestCase:
 
     def tearDown(self) -> None:
         pass
+
+    def getTestNames(self):
+        testNames = [testName for testName in dir(
+            self) if testName.startswith("test")]
+        return testNames

--- a/src/test_case_test.py
+++ b/src/test_case_test.py
@@ -4,7 +4,7 @@ from test_result import TestResult
 from broken_setup import TestCaseWithBrokenSetup
 from test_suite import TestSuite
 from broken_teardown import TestCaseWithBrokenTearDown
-
+from no_op_test_case import NoOpTestCase
 
 class TestCaseTest(TestCase):
     def setUp(self) -> None:

--- a/src/test_case_test.py
+++ b/src/test_case_test.py
@@ -48,6 +48,10 @@ class TestCaseTest(TestCase):
         test.run(self.result)
         assert ("setUp testBrokenMethod tearDown " == test.log)
 
+    def testCollectAllTestNames(self) -> None:
+        test = NoOpTestCase('testMethod')
+        assert (test.getTestNames() == ["testMethod", "testMethod2"])
+
 
 suite = TestSuite()
 suite.add(TestCaseTest("testTemplateMethod"))
@@ -57,6 +61,7 @@ suite.add(TestCaseTest("testFailedSetUp"))
 suite.add(TestCaseTest("testSuite"))
 suite.add(TestCaseTest("testFailedTearDown"))
 suite.add(TestCaseTest("testTearDownCalledEvenIfTestFails"))
+suite.add(TestCaseTest("testCollectAllTestNames"))
 
 result = TestResult()
 suite.run(result)

--- a/src/test_case_test.py
+++ b/src/test_case_test.py
@@ -62,17 +62,7 @@ class TestCaseTest(TestCase):
         assert (result.summary() == "2 run, 0 failed")
 
 
-suite = TestSuite()
-suite.add(TestCaseTest("testTemplateMethod"))
-suite.add(TestCaseTest("testFailedResultFormatting"))
-suite.add(TestCaseTest("testFailedResult"))
-suite.add(TestCaseTest("testFailedSetUp"))
-suite.add(TestCaseTest("testSuite"))
-suite.add(TestCaseTest("testFailedTearDown"))
-suite.add(TestCaseTest("testTearDownCalledEvenIfTestFails"))
-suite.add(TestCaseTest("testCollectAllTestNames"))
-suite.add(TestCaseTest("testReturnsTestSuite"))
-
+suite = TestCaseTest('anything').asSuite()
 result = TestResult()
 suite.run(result)
 print(result.summary())

--- a/src/test_case_test.py
+++ b/src/test_case_test.py
@@ -6,6 +6,7 @@ from test_suite import TestSuite
 from broken_teardown import TestCaseWithBrokenTearDown
 from no_op_test_case import NoOpTestCase
 
+
 class TestCaseTest(TestCase):
     def setUp(self) -> None:
         self.result = TestResult()
@@ -52,6 +53,14 @@ class TestCaseTest(TestCase):
         test = NoOpTestCase('testMethod')
         assert (test.getTestNames() == ["testMethod", "testMethod2"])
 
+    def testReturnsTestSuite(self) -> None:
+        suite = NoOpTestCase('testMethod').asSuite()
+        assert (len(suite.tests) == 2)
+
+        result = TestResult()
+        suite.run(result)
+        assert (result.summary() == "2 run, 0 failed")
+
 
 suite = TestSuite()
 suite.add(TestCaseTest("testTemplateMethod"))
@@ -62,6 +71,7 @@ suite.add(TestCaseTest("testSuite"))
 suite.add(TestCaseTest("testFailedTearDown"))
 suite.add(TestCaseTest("testTearDownCalledEvenIfTestFails"))
 suite.add(TestCaseTest("testCollectAllTestNames"))
+suite.add(TestCaseTest("testReturnsTestSuite"))
 
 result = TestResult()
 suite.run(result)


### PR DESCRIPTION
## Bonus: create a `TestSuite` from `TestCase`

Our goal is this chapter was to be able to create an instance of `TestSuite` from a `TestCase` class. This was implemented by using some reflection to extract all method names starting with the word `test` in the `TestCase` instance and then using it to create a slice of its own class for each test method, populating a `TestSuite` instance in each iteration. The result of this tricky computation was a `TestCase.asSuite()` method that returns a test suite instance containing all the test methods.

As a result of this approach, the `name` property ended up in a weird  state, as it's now ignored sometimes due to the "outermost" `TestCase` instance returning a suite.

Closes #14 